### PR TITLE
Remove line that corrupts offset variable when parsing 6101 CDP

### DIFF
--- a/ST2110-40.lua
+++ b/ST2110-40.lua
@@ -403,7 +403,6 @@ do
             local value = 0
             local buffer_size=0
 
-            offset=s+2
             s=s+2   -- section type + section count
             dSize=dataSection_Count*3
             s=s+dSize


### PR DESCRIPTION
I found a line that was causing parse errors for ANC packets that followed a 6101 within the same 2110 packet; the subsequent packets would be indexed incorrectly when the dissector tried to perform ANC analysis.