### PR TITLE
Fix CC parsing, improved TC display, group ANC packet info together, add checksum validation

### DIFF
--- a/ST2110-40.lua
+++ b/ST2110-40.lua
@@ -356,7 +356,7 @@ do
         -- Timecode format
         -- (UDW-15 & UDW-13)hours | (UDW-11 & UDW-9)minutes | (UDW-7 & UDW-5)seconds |
         -- (UDW-3 & UDW-1)frames
-        local ttvb=time_Table:tvb()
+        local ttvb=ByteArray.tvb(time_Table, "TimeCode")
         local timeStr = string.format("%d%dH:%d%dm:%d%ds:%d%dframes",
           ttvb(14,1):bitfield(6,2),
           ttvb(12,1):bitfield(4,4),
@@ -366,7 +366,7 @@ do
           ttvb(4,1):bitfield(4,4),
           ttvb(2,1):bitfield(6,2),
           ttvb(0,1):bitfield(4,4) )
-        tree_data:add(F.TimeCode, timeStr)
+        tree_data:add(F.TimeCode, ttvb(), timeStr):set_generated()
 
 
         -- Decode DBB1 (payload type) and DBB2 (VITC status) fields
@@ -381,21 +381,17 @@ do
         end
 
         -- We display DBB1 as the payload type
-        tree_data:add(F.TimeCodePT, dbb1)
+        tree_data:add(F.TimeCodePT, dbb1):set_generated()
 
         -- Display the DBB2 data next, even if it isn't VITC (probably zero)
-        local tree_dbb2 = tree_data:add(F.TimeCodeVITC, dbb2)
+        local tree_dbb2 = tree_data:add(F.TimeCodeVITC, dbb2):set_generated()
 
         -- Decode DBB2 (VITC) details when DBB1 == VITC
         if (dbb1 == 0x01 or dbb1 == 0x02) then
-          local dbb2_table=ByteArray.new("00")
-          dbb2_table:set_index(0, dbb2)
-
-          local dtvbr = dbb2_table:tvb()(0,1)
-          tree_dbb2:add(F.TimeCodeVitcLineSel, dtvbr:bitfield(7-5,5))
-          tree_dbb2:add(F.TimeCodeVitcLineDup, dtvbr:bitfield(7-5,5))
-          tree_dbb2:add(F.TimeCodeVitcValidity, dtvbr:bitfield(7-5,5))
-          tree_dbb2:add(F.TimeCodeVitcProcess, dtvbr:bitfield(7-5,5))
+          tree_dbb2:add(F.TimeCodeVitcLineSel, dbb2):set_generated()
+          tree_dbb2:add(F.TimeCodeVitcLineDup, dbb2):set_generated()
+          tree_dbb2:add(F.TimeCodeVitcValidity, dbb2):set_generated()
+          tree_dbb2:add(F.TimeCodeVitcProcess, dbb2):set_generated()
         end
       -- End of timecode format parsing
 

--- a/ST2110-40.lua
+++ b/ST2110-40.lua
@@ -403,6 +403,7 @@ do
             local value = 0
             local buffer_size=0
 
+            local cdp_offset=s+2
             s=s+2   -- section type + section count
             dSize=dataSection_Count*3
             s=s+dSize
@@ -421,12 +422,12 @@ do
 
               -- parsing CC_Data type
               -- TODO: maybe take the 2 LSB bits
-              CDP_CC_Type=ntvb(offset+n,1):bitfield(0,8)
+              CDP_CC_Type=ntvb(cdp_offset+n,1):bitfield(0,8)
               CC_type_str=tree_data:add(F.CCType, CDP_CC_Type)
               if CC_TYPE[CDP_CC_Type] then
                 CC_type_str:append_text(": "..CC_TYPE[CDP_CC_Type])
               end
-              value=ntvb(offset+n+1,2)
+              value=ntvb(cdp_offset+n+1,2)
               tree_data:add(F.CCValue,value)
 
               -- The first CDP_CC_Type is the service designated
@@ -440,8 +441,8 @@ do
               -- Service 2 is the Secondary Language Service
               -- We collect only data from the first service (serviceNb==0xfc)
               if CDP_CC_Type == 0xFE and serviceNb == 0xFC then
-                CC_concat:set_index(buffer_size*2, ntvb(offset+n+1,1):bitfield(0,8))
-                CC_concat:set_index(buffer_size*2+1, ntvb(offset+n+2,1):bitfield(0,8))
+                CC_concat:set_index(buffer_size*2, ntvb(cdp_offset+n+1,1):bitfield(0,8))
+                CC_concat:set_index(buffer_size*2+1, ntvb(cdp_offset+n+2,1):bitfield(0,8))
                 buffer_size=buffer_size+1
               end
               n=n+3

--- a/ST2110-40.lua
+++ b/ST2110-40.lua
@@ -47,7 +47,7 @@ do
   F.SDID=ProtoField.uint16("st_2110_40.SDID","SDID",base.HEX,nil,0x0FF0)
   F.UDW=ProtoField.bytes("st_2110_40.UDW","UDW Bytes", base.SPACE)
   F.UDW_array=ProtoField.bytes("st_2110_40.UDW_array","UDW Array", base.SPACE)
-  F.Checksum=ProtoField.uint16("st_2110_40.Checksum","Checksum Word test",base.HEX,nil)
+  F.Checksum=ProtoField.uint16("st_2110_40.Checksum","Checksum Word",base.HEX,nil)
   F.Checksum_Calc=ProtoField.uint16("st_2110_40.Checksum_Calculated","Calculated Checksum",base.HEX,nil)
 
 -- User Data Structure


### PR DESCRIPTION
**New features:**
- Each ANC packet is now inside a collapsible section (with DID/SDID in label), to make it easier to identify each ANC packet
- Added display and validation of the ANC packet checksum. Incorrect checksums are flagged using Expert info.
- Improved timecode handling (now displays timecode payload type & decodes VITC bits)

**Bug fixes:**
- The recent fix for CC decoding corrupting subsequent packets (1aa3555e115) broke the CC decoding (restoring the value of the 'offset' variable meant the places it was used in the CC parsing got the wrong data). The original CC parsing behaviour is restored, while preventing the corruption of other ANC packets.
- Fixed the highlighting of UDW / checksum bytes in the Packet Bytes pane. Previously, the last UDW byte and last checksum byte weren't highlighted correctly in some cases.