### PR TITLE
Bugfix for OP-47 byte reversal, and additions for X/26 parsing

### DIFF
--- a/ST2110-40.lua
+++ b/ST2110-40.lua
@@ -855,7 +855,9 @@ end
             bitFlippedData:set_size(42)
             for i=0,41 do
               local byte = ntvb(offsetB+3+i, 1):uint()
-              local reversed = ReverseByte[bit32.band(byte+1, 0xff)]
+              if (byte >= 255) then byte = 0 end
+              byte = byte+1
+              local reversed = ReverseByte[byte]
               bitFlippedData:set_index(i, reversed)
             end
 


### PR DESCRIPTION
Byte-reversing for OP-47 payloads did not account for wrap, causing parsing of X/26 payloads to fail.
After fixing that, I also added rudimentary parsing of X/26 payloads.
(An accompanying sample 'ST2110-40_OP47_French_Diacriticals.pcap' has been submitted to the ST2110_pcap_zoo repo.)